### PR TITLE
Changes to hydroponics trays and planting beds.

### DIFF
--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -19,7 +19,7 @@
 	var/maxWaterLevel = 100
 	var/maxNutriLevel = 10
 	var/maxPestLevel = 10
-	var/maxWeedLevel = 10
+	var/maxWeedLevel = 0 // Hydroponics systems don't grow weeds irl. Pests are still an issue.
 
 	// Tray state vars.
 	var/dead = 0               // Is it dead?
@@ -33,7 +33,7 @@
 	var/mutation_mod = 0       // Modifier to mutation chance
 	var/toxins = 0             // Toxicity in the tray?
 	var/mutation_level = 0     // When it hits 100, the plant mutates.
-	var/tray_light = 1         // Supplied lighting.
+	var/tray_light = 5         // Supplied lighting.
 
 	// Mechanical concerns.
 	var/health = 0             // Plant health.

--- a/code/modules/hydroponics/trays/tray_process.dm
+++ b/code/modules/hydroponics/trays/tray_process.dm
@@ -20,8 +20,9 @@
 
 	// Weeds like water and nutrients, there's a chance the weed population will increase.
 	// Bonus chance if the tray is unoccupied.
-	if(waterlevel > 10 && nutrilevel > 2 && prob(isnull(seed) ? 5 : 1))
-		weedlevel += 1 * HYDRO_SPEED_MULTIPLIER
+	if(!mechanical) // Changes it so that only soil plots need to worry about weeds.
+		if(waterlevel > 10 && nutrilevel > 2 && prob(isnull(seed) ? 5 : 1))
+			weedlevel += 1 * HYDRO_SPEED_MULTIPLIER
 
 	// There's a chance for a weed explosion to happen if the weeds take over.
 	// Plants that are themselves weeds (weed_tolerance > 10) are unaffected.

--- a/code/modules/hydroponics/trays/tray_soil.dm
+++ b/code/modules/hydroponics/trays/tray_soil.dm
@@ -5,7 +5,9 @@
 	use_power = 0
 	mechanical = 0
 	tray_light = 0
-
+	waterlevel = 0
+	nutrilevel = 0 // So they don't spawn with water or nutrient when built. Soil's hard mode, baby.
+	maxWeedLevel = 10 // Retains the ability for soil to grow weeds, as it should.
 /obj/machinery/portable_atmospherics/hydroponics/soil/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	//A special case for if the container has only water, for manual watering with buckets
 	if (istype(O,/obj/item/weapon/reagent_containers))
@@ -23,6 +25,12 @@
 
 	if(istype(O,/obj/item/weapon/tank))
 		return
+	if(istype(O,/obj/item/weapon/shovel))
+		if(do_after(user, 50))
+			new /obj/item/stack/material/sandstone{amount = 3}(loc)
+			user << "<span class='notice'>You remove the soil from the bed and dismantle the sandstone base.</span>"
+			playsound(src, 'sound/effects/stonedoor_openclose.ogg', 40, 1)
+			qdel(src)
 	else
 		..()
 

--- a/code/modules/hydroponics/trays/tray_update_icons.dm
+++ b/code/modules/hydroponics/trays/tray_update_icons.dm
@@ -68,7 +68,7 @@
 			add_overlay("over_lowwater3")
 		if(nutrilevel <= 2)
 			add_overlay("over_lownutri3")
-		if(weedlevel >= 5 || pestlevel >= 5 || toxins >= 40)
+		if(pestlevel >= 5 || toxins >= 40) // Hydroponics trays no longer face issues with weeds. GET OUTTA HERE.
 			add_overlay("over_alert3")
 		if(harvest)
 			add_overlay("over_harvest3")

--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -26,6 +26,8 @@
 		recipes += new/datum/stack_recipe("[display_name] knife", /obj/item/weapon/material/kitchen/utensil/knife/plastic, 1, on_floor = 1, supplied_material = "[name]")
 		recipes += new/datum/stack_recipe("[display_name] blade", /obj/item/weapon/material/butterflyblade, 6, time = 20, one_per_turf = 0, on_floor = 1, supplied_material = "[name]")
 		recipes += new/datum/stack_recipe("[display_name] spearhead", /obj/item/weapon/material/spearhead, 6, time = 20, one_per_turf = 0, on_floor = 1, supplied_material = "[name]")
+	if(name == "sandstone")
+		recipes += new/datum/stack_recipe("planting bed", /obj/machinery/portable_atmospherics/hydroponics/soil, 3, time = 10, one_per_turf = 1, on_floor = 1)
 
 /material/steel/generate_recipes()
 	..()
@@ -100,10 +102,6 @@
 	recipes += new/datum/stack_recipe("Metal crate", /obj/structure/closet/crate, 10, time = 50, one_per_turf = 1)
 	recipes += new/datum/stack_recipe("knife grip", /obj/item/weapon/material/butterflyhandle, 4, time = 20, one_per_turf = 0, on_floor = 1, supplied_material = "[name]")
 	recipes += new/datum/stack_recipe("dark floor tile", /obj/item/stack/tile/floor_dark, 1, 4, 20)
-
-/material/sandstone/generate_recipes()
-	..()
-	recipes += new/datum/stack_recipe("planting bed", /obj/machinery/portable_atmospherics/hydroponics/soil, 3, time = 10, one_per_turf = 1, on_floor = 1)
 
 /material/plastic/generate_recipes()
 	..()


### PR DESCRIPTION
- Adds building planting beds from sandstone
- Adds removing planting beds with shovels
- Removes ability for hydroponics trays to grow weeds
- Retains ability for soil plots to spawn weeds.
- Soil plots do not spawn with water or nutriment, requiring different upkeep for them.
- Removes the indicator criteria for the weeds, retains it for pests and toxins
- Adds change for recipe list for sandstone itself, to allow creating the planting beds.